### PR TITLE
Fix for AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The Ceph blueprint is set up to provide a basic scalable HA cluster by default. 
 | ceph.filesystem.metadata.name | Name of the metadata volume                           | cephfs_metadata |
 | ceph.filesystem.name          | Name of the filesystem                                | ceph            |
 | ceph.block.device.name        | Name of the block device                              | ceph-vol        |
+| ceph.osd.device               | The device to use for ceph e.g. /dev/deviceN          | null (use OS)   |
 
 ## Usage
 

--- a/catalog/ceph/ceph.bom
+++ b/catalog/ceph/ceph.bom
@@ -59,6 +59,7 @@ brooklyn.catalog:
         default: true
       brooklyn.config:
         ceph.monitor.port: 5000
+        ceph.control.port: 6789
         shell.env:
           ENTITY_ID: $brooklyn:attributeWhenReady("entity.id")
           CEPH_RELEASE_NAME: $brooklyn:config("ceph.release.name")
@@ -1051,6 +1052,13 @@ brooklyn.catalog:
           The maximum number of OSDs
         type: integer
         default: 10
+      - name: ceph.osd.device
+        label: "Ceph OSD device"
+        description: |
+          The device to use for ceph e.g. /dev/deviceN
+          leave blank to use the OS drive.
+        type: string
+        pinned: false
       services:
       - type: ceph-monitor-cluster    
         id: monitor-cluster

--- a/tests/ceph/ceph.tests.bom
+++ b/tests/ceph/ceph.tests.bom
@@ -31,6 +31,9 @@ brooklyn.catalog:
       services:
       - type: ceph-template
         id: ceph
+        brooklyn.config:
+          # Some clouds give us very little free space
+          ceph.maximum.usage: 95
       - type: centos7-software-process
         id: ceph-mount-test-1
         name: "Ceph Mount Test 1"


### PR DESCRIPTION
* Explicitly opens the control port
* Adds the ability to specify the block device on ODSs
* Upps the max usage to 95% in the tests as some clouds (such as AWS) have small OS drives.