### PR TITLE
Add fixes for mongodb and Ceph startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The Ceph blueprint is set up to provide a basic scalable HA cluster by default. 
 | ceph.filesystem.name          | ceph            | Name of the filesystem                                |
 | ceph.block.device.name        | ceph-vol        | Name of the block device                              |
 | ceph.osd.device               | null (use OS)   | The device to use for ceph e.g. /dev/deviceN          |
-| ceph.enable.ext4              | false           | See: goo.gl/Qqthbt                                    |
+| ceph.enable.ext4              | false           | See: http://goo.gl/Qqthbt                             |
 
 ## Usage
 

--- a/catalog/ceph/ceph.bom
+++ b/catalog/ceph/ceph.bom
@@ -711,10 +711,10 @@ brooklyn.catalog:
             brooklyn.config:
               customize.latch: $brooklyn:parent().attributeWhenReady("cluster.first.entity").attributeWhenReady("service.isUp")
               shell.env:
-                CEPH_MON_PRIMARY_HOSTNAME: $brooklyn:attributeWhenReady("cluster.first.entity").attributeWhenReady("host.subnet.address")
-                CEPH_CLIENT_ADMIN_KEYRING: $brooklyn:attributeWhenReady("cluster.first.entity").attributeWhenReady("ceph.client.admin.keyring")
+                CEPH_MON_PRIMARY_HOSTNAME: $brooklyn:parent().attributeWhenReady("cluster.first.entity").attributeWhenReady("host.subnet.address")
+                CEPH_CLIENT_ADMIN_KEYRING: $brooklyn:parent().attributeWhenReady("cluster.first.entity").attributeWhenReady("ceph.client.admin.keyring")
                 CEPH_MON_HOSTNAMES: $brooklyn:parent().attributeWhenReady("ceph.monitor.hostnames")
-                CEPH_MON_FSID: $brooklyn:attributeWhenReady("cluster.first.entity").attributeWhenReady("ceph.monitor.fsid")
+                CEPH_MON_FSID: $brooklyn:parent().attributeWhenReady("cluster.first.entity").attributeWhenReady("ceph.monitor.fsid")
       brooklyn.enrichers:
         - type: org.apache.brooklyn.enricher.stock.Aggregator
           brooklyn.config:

--- a/catalog/inkscope/mongodb.bom
+++ b/catalog/inkscope/mongodb.bom
@@ -79,6 +79,7 @@ brooklyn.catalog:
           gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc
           EOF
           
+          sudo yum update -y
           sudo yum install -y mongodb-org git nodejs
           
           git clone https://github.com/mrvautin/adminMongo.git && cd adminMongo


### PR DESCRIPTION
* Updates mongodb to avoid problems like [this](https://stackoverflow.com/questions/46473376/node-relocation-error-node-symbol-ssl-set-cert-cb-version-libssl-so-10-not-d).
* Changes the `cluster.first.entity` config after changes to how this works in Brooklyn