### PR TITLE
Remove HTTP test for mongodb

### DIFF
--- a/catalog/inkscope/mongodb.bom
+++ b/catalog/inkscope/mongodb.bom
@@ -55,13 +55,6 @@ brooklyn.catalog:
           name: mongo.admin.port
           static.value: $brooklyn:config("mongo.admin.port")
       
-      brooklyn.enrichers:
-      - type: org.apache.brooklyn.enricher.stock.Transformer
-        brooklyn.config:
-          enricher.sourceSensor: $brooklyn:sensor("host.address")
-          enricher.targetSensor: $brooklyn:sensor("main.uri")
-          enricher.targetValue: $brooklyn:formatString("http://%s:%s", $brooklyn:attributeWhenReady("host.address"), $brooklyn:config("mongo.admin.port"))
-          
       brooklyn.config:
         mongo.port: 27017
         mongo.admin.port: 1234

--- a/tests/ceph/ceph.tests.bom
+++ b/tests/ceph/ceph.tests.bom
@@ -99,9 +99,6 @@ brooklyn.catalog:
           - type: test-http-status-200
             name: "2.1 Test Inkscope"
             url: $brooklyn:component("ceph").attributeWhenReady("main.uri")
-          - type: test-http-status-200
-            name: "2.2 Test MongoDB"
-            url: $brooklyn:component("mongodb").attributeWhenReady("main.uri")
             
         - type: test-case
           name: "3. Test Mount"


### PR DESCRIPTION
Since [mongodb 3.2](https://docs.mongodb.com/manual/release-notes/3.2/), the HTTP interface as been deprecated and completely removed in version 3.6.

This updates the tests to remove the relevant test.